### PR TITLE
Fix: Resolve `uccli` packaging issue due to symbolic link inclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+# Include the main underdogcowboy package
+recursive-include underdogcowboy *
+
+# Include the uccli package
+recursive-include uccli *
+
+# Exclude unwanted files
+prune **/__pycache__
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "underdogcowboy"
-version = "0.1.14"
+version = "0.1.14.1"
 description = "Underdog Cowboy (UC): Wrangle Your LLMs with a Smile"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/uccli
+++ b/uccli
@@ -1,1 +1,1 @@
-/Users/reneluijk/projects/uccli
+/Users/reneluijk/projects/uccli/uccli


### PR DESCRIPTION
### Commit Description:
- **Bug**: The `uccli` module, included via a symbolic link, was packaged incorrectly in the PyPI distribution. This caused the path to the `uccli` files to have an additional folder level, breaking imports like `from uccli import AgentCommunicator`. The issue stemmed from how the symbolic link was handled during the build process.
- **Fix**: Updated `MANIFEST.in` to explicitly include the `uccli` package using `recursive-include uccli *`. This ensured all necessary files were packaged correctly without redundant or extra directory nesting.
- **Improvement**: Added cleanup rules in `MANIFEST.in` to exclude `__pycache__` directories and `.pyc` files, resulting in a cleaner and more precise package.
- **Result**: The `uccli` module is now included correctly in the PyPI package, and imports function as expected after installation.

This resolves the path issue caused by the symbolic link and ensures a properly structured distribution for end users.